### PR TITLE
Cloud Foundry influxdb service

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>1.8</java.version>
+        <influxdb.connectors.version>1.0.6</influxdb.connectors.version>
     </properties>
 
     <dependencies>
@@ -49,6 +50,19 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>com.orange.spring.cloud.connectors</groupId>
+            <artifactId>spring-cloud-influxdb-spring-service-connector</artifactId>
+            <version>${influxdb.connectors.version}</version>
+        </dependency>
+        <!-- If you intend to deploy the app on Cloud Foundry, add the following -->
+        <dependency>
+            <groupId>com.orange.spring.cloud.connectors</groupId>
+            <artifactId>spring-cloud-influxdb-connectors-cloudfoundry</artifactId>
+            <version>${influxdb.connectors.version}</version>
+        </dependency>
+
     </dependencies>
 
     <build>
@@ -71,6 +85,22 @@
             <releases>
                 <enabled>true</enabled>
             </releases>
+        </repository>
+        <repository>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>bintray-elpaaso-maven</id>
+            <name>bintray</name>
+            <url>http://dl.bintray.com/elpaaso/maven</url>
+        </repository>
+        <repository>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>central</id>
+            <name>bintray</name>
+            <url>http://jcenter.bintray.com</url>
         </repository>
     </repositories>
 

--- a/src/main/java/com/example/InfluxDBMetricWriter.java
+++ b/src/main/java/com/example/InfluxDBMetricWriter.java
@@ -21,14 +21,14 @@ public class InfluxDBMetricWriter implements GaugeWriter {
     private static final int DEFAULT_FLUSH_DURATION = 30;
 
     private final InfluxDB influxDB;
-    private final String databaseName;
+    //private final String databaseName;
     private String appInstanceId;
 
     private InfluxDBMetricWriter(Builder builder) {
         this.influxDB = builder.influxDB;
-        this.databaseName = builder.databaseName;
+        //this.databaseName = builder.databaseName;
         this.appInstanceId = builder.appInstanceId;
-        this.influxDB.createDatabase(this.databaseName);
+        //this.influxDB.createDatabase(this.databaseName);
         this.influxDB.enableBatch(builder.batchActions, builder.flushDuration,
                 builder.flushDurationTimeUnit);
         this.influxDB.setLogLevel(builder.logLevel);
@@ -41,7 +41,7 @@ public class InfluxDBMetricWriter implements GaugeWriter {
                 .tag("app_instance_id",this.appInstanceId)
                 .addField("value", value.getValue())
                 .build();
-        this.influxDB.write(this.databaseName, null, point);
+        this.influxDB.write(point);
     }
 
     @Accessors(fluent = true, chain = true)

--- a/src/main/java/com/example/MetricsInfluxdbSampleApplication.java
+++ b/src/main/java/com/example/MetricsInfluxdbSampleApplication.java
@@ -20,9 +20,6 @@ import org.springframework.web.bind.annotation.RestController;
 @SpringBootApplication
 public class MetricsInfluxdbSampleApplication {
 
-    @Value("${influxdb.dbname:my-metrics}")
-    private String dbName;
-
     @Value("${cloud.application.instance_id:app_01}")
     private String appInstanceId;
 
@@ -43,11 +40,8 @@ public class MetricsInfluxdbSampleApplication {
     @Bean
     @ExportMetricWriter
     GaugeWriter influxMetricsWriter() {
-        // the name of the datastore you choose
-        influxDB.createDatabase(dbName);
         InfluxDBMetricWriter.Builder builder = new InfluxDBMetricWriter.Builder(influxDB);
         builder.appInstanceId(appInstanceId);
-        builder.databaseName(dbName);
         builder.batchActions(500);    // number of points for batch before data is sent to Influx
         return builder.build();
     }


### PR DESCRIPTION
Add spring cloud influxdb connector to simplify the process of connecting to influxdb service when deployed on Cloud Foundry.

[#1]